### PR TITLE
Enable user overrides for ruff linter

### DIFF
--- a/compiler/ruff.vim
+++ b/compiler/ruff.vim
@@ -14,7 +14,8 @@ let current_compiler = "ruff"
 let s:cpo_save = &cpo
 set cpo&vim
 
-setlocal makeprg=ruff\ check\ --preview\ --output-format=concise
+let g:compiler_ruff_options = get(g:, "compiler_ruff_options", "--preview")
+let &makeprg="ruff check " . g:compiler_ruff_options . " --output-format=concise"
 setlocal errorformat=%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l:%c\ -\ %m,%f:
 
 silent CompilerSet makeprg


### PR DESCRIPTION
Hi @Konfekt , thanks for this really useful plugin! :)

This PR enables the user tospecify the `g:compiler_ruff_options` variable, e.g., as part of their `vimrc` and override the ruff options that are being used in `ruff check`.

This is useful because for example in projects that I'm using we have not enabled the `--preview` flag of ruff and that causes discrepancies with the results reported by CI.